### PR TITLE
Update hooks-generator and relocate entry point to package

### DIFF
--- a/package/hooks_generator/hooks_src/api/hooks-api.ts
+++ b/package/hooks_generator/hooks_src/api/hooks-api.ts
@@ -1,3 +1,4 @@
+import { Transaction } from './../../../recoil_generator/src/types';
 
 /* eslint-disable */
 //import useState and useReducer from React
@@ -42,13 +43,14 @@ import { Dispatch,BasicStateAction } from '../hooks-types';
 // }
 
 
-export function useState (initialState: any ) {
+export default function useState (initState: any ) {
   //bring in the state property from our ledger, which is of type array
-  const { state } = hooksLedger;
+  const { transactions } = hooksLedger;
 
   //push our the users intial state into our ledger
-  state.push(initialState)
-  const tracker = reactUseState(initialState)
+  transactions.initialState.push(initState)
+  transactions.currState.push(initState)
+  const tracker = reactUseState(initState)
 
   return tracker; // [ state, setState]
  

--- a/package/hooks_generator/hooks_src/component/HooksChromogenObserver.ts
+++ b/package/hooks_generator/hooks_src/component/HooksChromogenObserver.ts
@@ -60,27 +60,27 @@ export const hooksChromogenObserver: React.FC<store> = ({ store }) => {
   //   })
 
   // usePrevious custom hook for grabbing the previous state value
-  function usePrevious(value: any) {
-    // useRef will return a mutable ref object with a current property initialized to the current passed in argument. This object will persist for full lifetime of the component
-    const ref = useRef();
-    // Store current value in ref
-    useEffect(() => {
-      ref.current = value;
-    }, [value]); // Only re-run if value changes
+  // function usePrevious(value: any) {
+  //   // useRef will return a mutable ref object with a current property initialized to the current passed in argument. This object will persist for full lifetime of the component
+  //   const ref = useRef();
+  //   // Store current value in ref
+  //   useEffect(() => {
+  //     ref.current = value;
+  //   }, [value]); // Only re-run if value changes
 
-    return ref.current; // Previous value (happens before update in useEffect)
-  }
+  //   return ref.current; // Previous value (happens before update in useEffect)
+  // }
 
-  // useReactTransactionObserver
+  // useEffect to check if tracker[1] was invoked
   const useReactTransactionObserver = (prevState: any, currState: any) => {
     // For [state, setState], when setState is invoked, we want to push the prevState and currState to our transactions state array. Else => nothing is done (void function)
-    if (transactions[state] > 0) {
+    if (tracker[state] > 0) {
       const { transactions } = ledger;
 
       // newState
 
       // prevState
-      prevState = usePrevious()
+      //prevState = usePrevious()
     }
   };
 

--- a/package/hooks_generator/hooks_src/hooks-types.ts
+++ b/package/hooks_generator/hooks_src/hooks-types.ts
@@ -15,4 +15,11 @@ export all types and interfaces
 
 export type BasicStateAction<S> = (S => S) | S;
 export type Dispatch<A> = A => void;
+export interface Transaction {
+  initialState: [],//1
+  prevState: [], //2
+  currState: [],//1  2  3
+  setStateCallback: [], 
+  count: number =  0,//2
+}
 

--- a/package/hooks_generator/hooks_src/utils/hooks-ledger.ts
+++ b/package/hooks_generator/hooks_src/utils/hooks-ledger.ts
@@ -1,6 +1,8 @@
+import { Transaction } from '../hooks-types';
 /* eslint-disable */
 import React, { useState, useEffect, useRef } from 'react';
 import { Ledger } from '../types';
+
 /* eslint-enable */
 
 // Import & add type for ledger later on?
@@ -8,21 +10,14 @@ import { Ledger } from '../types';
 // Ledger will contain state(current, prev), when setState is invoked = count > 0
 
 export const hooksLedger: any {
-  transactions: {
-    initialState: [],
-    prevState: [], 
-    currState: '',
-    setStateCallback: [], 
-    count: 0,
-    
-   }
+  Transaction: []
 };
 
 // *******Logic for tracking previous state and whether setState cb has been invoked*******
 // When user first imports Chromogen into their app: initialState, currState and setStateCallback will update AND intitalState === currState
 //--------
-// After setStateCallback is invoked:
+// After setStateCallback is invoked: which means tracker[0] !== currState
 // 1) Check if there is anything in prevState. If so, delete. 
 // 2) Increase value of count by 1 
 // 3) Push value of currState to prevState
-// 4) Replace currState with newly evaluated result of currState
+// 4) Replace currState with newly evaluated result of currState at tracker[0]

--- a/package/index.ts
+++ b/package/index.ts
@@ -1,0 +1,8 @@
+/* eslint-disable */
+import { atom, selector, atomFamily, selectorFamily } from './recoil_generator/src/api/api';
+import { ChromogenObserver } from './recoil_generator/src/component/ChromogenObserver';
+import useState from './hooks_generator/hooks_src/api/hooks-api'
+import { hooksChromogenObserver } from './hooks_generator/hooks_src/component/HooksChromogenObserver';
+// CHROMGOEN FAMILY APIs ARE CURRENTLY UNSTABLE
+// import { atomFamily, selectorFamily } from 'recoil';
+export { atom, selector, atomFamily, selectorFamily, ChromogenObserver, hooksChromogenObserver, useState };

--- a/package/recoil_generator/src/index.ts
+++ b/package/recoil_generator/src/index.ts
@@ -1,7 +1,0 @@
-/* eslint-disable */
-import { atom, selector, atomFamily, selectorFamily } from './api/api';
-import { ChromogenObserver } from './component/ChromogenObserver';
-// CHROMGOEN FAMILY APIs ARE CURRENTLY UNSTABLE
-// import { atomFamily, selectorFamily } from 'recoil';
-
-export { atom, selector, atomFamily, selectorFamily, ChromogenObserver };

--- a/package/tsconfig.json
+++ b/package/tsconfig.json
@@ -5,7 +5,7 @@
     "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "outDir": "./build" /* Redirect output structure to the directory. */,
-    "rootDirs": ["./recoil_generator/src", "./hooks_generator/hooks_src"] /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+    "rootDir": "." /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     "removeComments": true /* Do not emit comments to output. */,
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,


### PR DESCRIPTION
Update hooks-generator and relocate entry point to package

## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
Move index.ts to root of package, update hooks-ledger data type, add Transaction type to hooks-ledger"
## Approach
We now have the correct entry point for our package and have removed type ambiguity from our ledger


