### PR TITLE
Correct id in HooksChromogenObserver

### DIFF
--- a/package/hooks_generator/hooks_src/component/HooksChromogenObserver.tsx
+++ b/package/hooks_generator/hooks_src/component/HooksChromogenObserver.tsx
@@ -11,7 +11,7 @@ import { useState as hooksUseState } from '../api/hooks-api'
 // const hooksRecordingState = true;
 
 // Export hooksChromogenObserver
-export const hooksChromogenObserver: React.FC<{initState: any}> = ({initState}) => {
+export const HooksChromogenObserver: React.FC<{initState?: any}> = ({initState}) => {
   // Initializing as undefined over null to match React typing for AnchorHTML attributes
   // File will be string
   const [file, setFile] = reactUseState<undefined | string>(undefined);
@@ -51,7 +51,7 @@ export const hooksChromogenObserver: React.FC<{initState: any}> = ({initState}) 
   });
 
   // Auto-click download link when a new file is generated (via button click)
-  useEffect(() => document.getElementById('chromogen-download')!.click(), [file]);
+  useEffect(() => document.getElementById('chromogen-hooks-download')!.click(), [file]);
 
   // usePrevious custom hook for grabbing the previous state value
   // function usePrevious(value: any) {

--- a/package/hooks_generator/hooks_src/hooks-index.ts
+++ b/package/hooks_generator/hooks_src/hooks-index.ts
@@ -8,9 +8,9 @@ export useState, useReducer, and hooksObserver
 import { useState } from './api/hooks-api';
 
 // Does name matter when user imports into app?
-import { hooksChromogenObserver } from './component/HooksChromogenObserver';
+import { HooksChromogenObserver } from './component/HooksChromogenObserver';
 
 export {
     useState,
-    hooksChromogenObserver
+    HooksChromogenObserver
 }

--- a/package/index.ts
+++ b/package/index.ts
@@ -2,7 +2,7 @@
 import { atom, selector, atomFamily, selectorFamily } from './recoil_generator/src/api/api';
 import { ChromogenObserver } from './recoil_generator/src/component/ChromogenObserver';
 import { useState } from './hooks_generator/hooks_src/api/hooks-api'
-import { hooksChromogenObserver } from './hooks_generator/hooks_src/component/HooksChromogenObserver';
+import { HooksChromogenObserver } from './hooks_generator/hooks_src/component/HooksChromogenObserver';
 // CHROMGOEN FAMILY APIs ARE CURRENTLY UNSTABLE
 // import { atomFamily, selectorFamily } from 'recoil';
-export { atom, selector, atomFamily, selectorFamily, ChromogenObserver, hooksChromogenObserver, useState };
+export { atom, selector, atomFamily, selectorFamily, ChromogenObserver, HooksChromogenObserver, useState };


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
HooksChromgenObserver had an incorrect id 
## Approach
Buttons in HooksChromgenObserver now render

