### PR TITLE
add togglable record icon to show when state is recording

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -57,8 +57,7 @@
     "react-dom": "^16.13.1",
     "react-keyframes": "^0.2.3",
     "react-recoil-hooks-testing-library": "0.0.8",
-    "recoil": "0.0.13",
-    "styled-components": "^5.2.0"
+    "recoil": "0.0.13"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/package/recoil_generator/src/component/ChromogenObserver.tsx
+++ b/package/recoil_generator/src/component/ChromogenObserver.tsx
@@ -12,6 +12,7 @@ import GetAppIcon from '@material-ui/icons/GetApp';
 import PauseIcon from '@material-ui/icons/Pause';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import { styled } from '@material-ui/core/styles';
+import Record from './Record'
 /* eslint-enable */
 
 export const ChromogenObserver: React.FC<{ store?: Array<object> | object }> = ({ store }) => {
@@ -150,30 +151,39 @@ export const ChromogenObserver: React.FC<{ store?: Array<object> | object }> = (
     },
   });
 
+
+
+
+
   return (
     <>
       {
         // Render button div only if DevTool not connected
         !devtool && (
-          <div style={styles.divStyle}>
-            <button
-              aria-label={recording ? 'pause' : 'record'}
-              id="chromogen-toggle-record"
-              style={{ ...styles.buttonStyle, backgroundColor: '#7f7f7f' }}
-              type="button"
-              onClick={() => {
-                setRecording(!recording);
-              }}
-              >{recording ? <MyPauseIcon/> : <MyPlayArrowIcon/> }
-            </button>
-            <button
-              aria-label="capture test"
-              id="chromogen-generate-file"
-              style={{ ...styles.buttonStyle, backgroundColor: '#7f7f7f', marginLeft: '-2px', marginRight: '13px' }}
-              type="button"
-              onClick={() => generateFile(setFile, storeMap)}
-              ><MyGetAppIcon/>
-            </button>
+          <div>
+            {recording ? <Record/> : <div></div>}
+            {/* <Record/> */}
+            <div style={styles.divStyle}>
+              <button
+                aria-label={recording ? 'pause' : 'record'}
+                id="chromogen-toggle-record"
+                style={{ ...styles.buttonStyle, backgroundColor: '#7f7f7f' }}
+                type="button"
+                onClick={() => {
+                  setRecording(!recording);
+                }}
+                >{recording ? <MyPauseIcon/> : <MyPlayArrowIcon/>}
+              </button>
+              <button
+                aria-label="capture test"
+                id="chromogen-generate-file"
+                style={{ ...styles.buttonStyle, backgroundColor: '#7f7f7f', marginLeft: '-2px', marginRight: '13px' }}
+                type="button"
+                onClick={() => generateFile(setFile, storeMap)}
+                ><MyGetAppIcon/>
+              </button>
+            </div>
+
           </div>
         )
       }

--- a/package/recoil_generator/src/component/Record.tsx
+++ b/package/recoil_generator/src/component/Record.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
+import { styled } from '@material-ui/core/styles';
+import { styles } from './component-utils';
+
+
+const MyFiberManualRecordIcon = styled(FiberManualRecordIcon)({
+  height: 14,
+  color: 'red',
+  // position: 'fixed',
+  // animation: '${keyFrameRecord} 2s ease-in-out 0s infinite'
+});
+
+const Record: React.FC = () => {
+  return(
+    <span id="record-icon" style={styles.recordStyle}>
+      <MyFiberManualRecordIcon/>
+      Recording
+    </span>
+  )
+};
+
+export default Record;

--- a/package/recoil_generator/src/component/component-utils.ts
+++ b/package/recoil_generator/src/component/component-utils.ts
@@ -31,7 +31,22 @@ const divStyle: CSSProperties = {
   padding: 0,
   zIndex: 999999,
 };
-export const styles = { buttonStyle, divStyle };
+
+const recordStyle: CSSProperties = {
+  margin: '0px',
+  fontSize: '12px',
+  display: 'flex',
+  width: '95px',
+  color: 'white',
+  padding: '4px',
+  position: 'fixed',
+  borderRadius: '2px',
+  // border: '2px solid #7fe5f0',
+  flexDirection: 'row',
+  backgroundColor: '#7f7f7f'
+};
+
+export const styles = { buttonStyle, divStyle, recordStyle };
 
 /**
  * onclick function that generates test file & sets download URL


### PR DESCRIPTION
Co-authored-by: Ryan rtumel123@gmail.com

## Types of changes
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
Add togglable record icon to show when state is recording
## Approach
Conditionally rendered styled record icon based on togglable state recording
## Notes
Need fix on visible re-render (a slight blink occurs on page) when record is toggled the first time, but does not happen on subsequent toggles.
