### PR TITLE
Add testing coverage for output-utils.ts in recoil_generator

### DIFF
--- a/package/hooks_generator/hooks_src/output/hooks-output-utils.ts
+++ b/package/hooks_generator/hooks_src/output/hooks-output-utils.ts
@@ -6,17 +6,13 @@
 // import { Store } from 'redux';
 // import { EnhancedStore, StateInspectorContext } from '../utils/hooks-store';
 
-//transaction = how many times setState cb has fired
-
 //Testing logic for user's state
 //testing for edge cases in the user's app
 
 /* ----- HELPER FUNCTIONS ----- */
 
 /* ----- SETUP FUNCTIONS ----- */
-/*
 // set up functions to import user's useState and variables related to it: state variable (array), setState callback function & use regex to return outcomes
-*/
 
 //import hooks state from user's app
 export function importHooksInitialState(state: any) {

--- a/package/recoil_generator/__tests__/output-utils.test.js
+++ b/package/recoil_generator/__tests__/output-utils.test.js
@@ -4,13 +4,14 @@ import {
   testSelectors,
   testSetters,
   importRecoilFamily,
+  atomFamilyHook,
   //writeableHook,
   readableHook,
 } from '../src/output/output-utils.ts';
 
 // testing ternary operator in initializeAtoms helper function
 describe('initializeAtoms', () => {
-  // create mock atomUpdate object, follows AtomUpdate interface 
+  // create mock atomUpdate object, follows AtomUpdate interface
   const atomUpdate = {
     key: 'testAtom',
     value: 2,
@@ -75,8 +76,8 @@ describe('assertState', () => {
 describe('importRecoilFamily', () => {
   const familyObj = {
     familyName: 'string',
-    atomName: 'test'
-  }
+    atomName: 'test',
+  };
   it('should return a string with an object as its parameter', () => {
     expect(typeof importRecoilFamily(familyObj)).toBe('string');
   });
@@ -180,5 +181,42 @@ describe('testSetters', () => {
   it('should return a string if an array is passed in', () => {
     // verify that a string is returned if provided an array with out a setter object
     expect(typeof falsyReturnString).toBe('string');
+  });
+});
+
+// TEST FOR ATOMFAMILYHOOK lines 70-81
+//create mock transactionArray
+describe('atomFamilyHook', () => {
+  const transactionArray = [
+    {
+      atomFamilyState: [
+        {
+          key: 'spec!alCh@rspec!alCh@r',
+          family: 'familyName',
+          value: 10,
+          updated: true,
+        },
+      ],
+      familyUpdates: [
+        {
+          key: 'familyUpdate1',
+          value: 5,
+          params: 'params',
+        },
+      ],
+    },
+  ]; // truthy
+
+  const transactionArray2 = []; // falsy
+
+  const truthyReturnStr = atomFamilyHook(transactionArray);
+  const falsyReturnStr = atomFamilyHook(transactionArray2);
+
+  it('should scrub special characters', () => {
+    expect(truthyReturnStr).toEqual(expect.not.stringContaining('spec!alCh@r'));
+  });
+
+  it('should return empty string when transactionsArr length is falsy', () => {
+    expect(falsyReturnStr).toBe('');
   });
 });


### PR DESCRIPTION
## Types of changes
- [ ] Bugfix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [X] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
Add testing coverage for output-utils in recoil_generator 
## Approach
Increase testing coverage for output-utils.ts in recoil_generator 
## Resources
Jest documents
