### PR TITLE
Sung/dani/state array

### DIFF
--- a/daily-app/client/containers/MainContainer.tsx
+++ b/daily-app/client/containers/MainContainer.tsx
@@ -1,12 +1,7 @@
 import React, { useEffect } from 'react';
-// import React, { useEffect, useState } from 'react';
 import { useState as hooksUseState } from '../../../package/hooks_generator/hooks_src/api/hooks-api'
-// import Gratitude from '../components/Gratitude';
 
 const MainContainer: React.FC = () => {
-  // function MainContainer (){
-  // const [post, setPost] = hooksUseState<number[]>([0], "id");
-  // const [post, setPost] = useState();
 
   const [subtract, setSubtract] = hooksUseState<number>(0, 'subtract');
   const [count, setCount] = hooksUseState<number[]>([0], 'count');
@@ -16,8 +11,6 @@ const MainContainer: React.FC = () => {
     <p>You clicked {count} times</p>
     <button onClick={() => {
         setCount([count[0]+1])
-      //setCount([...count, count[count.length-1]+1])
-      console.log('count after setCount', count)
       }
     }>
     Count
@@ -26,8 +19,6 @@ const MainContainer: React.FC = () => {
      <p>You subtracted {subtract} times</p>
       <button onClick={() => {
         setSubtract(subtract - 1)
-      //setCount([...count, count[count.length-1]+1])
-      //console.log('count after setCount', count)
       }
     }>Subtract</button> 
 
@@ -38,8 +29,6 @@ const MainContainer: React.FC = () => {
         Don't click me
       </button>
   </div>
-
-  //  <Gratitude />
   )
 }
 

--- a/dev-tool/app/Components/App.tsx
+++ b/dev-tool/app/Components/App.tsx
@@ -54,7 +54,9 @@ const App: React.FC = () => {
       if (message.action === 'stateChange'){
        // console.log('state has been changed', message.result)
        //if state has changed from HooksChromogenObserver, stringify the object to display
-        setStateChange(JSON.stringify(message.stateObj));
+       setStateChange(message.stateObj)
+
+       // setStateChange(JSON.stringify(message.stateObj));
         //not sure if this can be sent back as an object. need to test on someone that can view console logs
       }
     });

--- a/dev-tool/content.ts
+++ b/dev-tool/content.ts
@@ -4,12 +4,12 @@
 
 // Relay messages from package to background.js (-> DevTools panel)
 window.addEventListener('message', (message) => {
-    console.log('inside content.ts - relay msg from package to background.js -> devtools panel', message)
+    //console.log('inside content.ts - relay msg from package to background.js -> devtools panel', message)
     chrome.runtime.sendMessage(message.data);
 });
 
 // Relay messages from background.js (DevTools panel listener) to package
 chrome.runtime.onMessage.addListener((message) => {
-    console.log('inside content.ts - relay msg from background to package', message)
+    //console.log('inside content.ts - relay msg from background to package', message)
     window.postMessage(message, '*');
 });

--- a/package/hooks_generator/hooks_src/api/hooks-api.ts
+++ b/package/hooks_generator/hooks_src/api/hooks-api.ts
@@ -19,6 +19,7 @@ function stateReducer<S>(state: S, action: StateAction<S>): S {
 
 export const useState = <S>(initialState: S | (() => S), id: string | number) => {
   const inspectorStore = useContext(ObserverContext);
+
   // Keeping the first values
   const [store, reducerId] = useMemo<[EnhancedStore | undefined, string | number]>(
     () => [inspectorStore, id],
@@ -33,7 +34,7 @@ export const useState = <S>(initialState: S | (() => S), id: string | number) =>
     () => (typeof initialState === 'function' ? (initialState as () => S)() : initialState),
     [],
   );
-
+  
   return useHookedReducer<S, any>(
     stateReducer,
     finalInitialState,

--- a/package/hooks_generator/hooks_src/api/hooks-core-utils.ts
+++ b/package/hooks_generator/hooks_src/api/hooks-core-utils.ts
@@ -1,3 +1,4 @@
+import { type } from 'os';
 import { useRef } from 'react';
 import { Reducer, useMemo, Dispatch, useState, useEffect } from 'react';
 import { hooksLedger } from '../utils/hooks-ledger';
@@ -11,21 +12,32 @@ export function useHookedReducer<S, A>(
 ): [S, Dispatch<A>] {
   
   const initialReducerState = useMemo(() => {
+    //console.log('reducerId', reducerId)
     const initialStateInStore = store.getState()[reducerId];
     return initialStateInStore === undefined ? initialState : initialStateInStore;
   }, []);
 
+  //console.log('initialreducer state', initialReducerState)
   const [localState, setState] = useState<S>(initialReducerState);
-  //Creating state property in store to save all state changes
+
+//Creating state property in store to save all state changes
+store.subscribe(() => {
+  hooksLedger.state = store.getState()[reducerId]
+  //console.log('hooks ledger after store is called on reducer id.', hooksLedger)
+});
+
+
  //wrapped store.subscribe method inside useEffect to avoid listening to change exponentially
- useEffect(() => {
-  const unsubscribe = store.subscribe(() => {
-    hooksLedger.state = store.getState()[reducerId]
-    //console.log('hooks', hooksLedger.state)
-  })
-  return unsubscribe;
- }, [])
+//  useEffect(() => {
+//   const unsubscribe = store.subscribe(() => {
+//     hooksLedger.state = store.getState()[reducerId]
+//     console.log('hooks ledger after store is called on reducer id.', hooksLedger)
+//   })
+//   return unsubscribe;
+//  }, [])
  
+
+
 const dispatch = useMemo<Dispatch<A>>(() => {
 
   const dispatch = (action: any) => {     
@@ -40,22 +52,27 @@ const dispatch = useMemo<Dispatch<A>>(() => {
           hooksLedger.state = store.getState()[reducerId];;
           hooksLedger.id = reducerId;
           hooksLedger.initialState = hooksLedger.state[0];
+          //console.log('initialState', initialState)
+          //hooksLedger.initialState = hooksLedger.currState;
 
-          hooksLedger.currState = hooksLedger.state[hooksLedger.state.length-1]
+          //hooksLedger.currState = hooksLedger.state[hooksLedger.state.length-1]
           //bug: dispCount is incremented each time store.subscribe is called
-          hooksLedger.dispCount = hooksLedger.dispCount + 1
+          //hooksLedger.dispCount = hooksLedger.dispCount + 1
           //console.log('dispatch count', hooksLedger.dispCount)
         });
        
         
-        // store.subscribe(() => {
-        //   hooksLedger.currState = hooksLedger.state[hooksLedger.state.length-1];
-        // });
+        store.subscribe(() => {
+          hooksLedger.currState = hooksLedger.state[hooksLedger.state.length-1];
+         //console.log('type of initialstate', typeof hooksLedger.initialState)
+        //  hooksLedger.initialState.push(hooksLedger.currState)
+        //   console.log('initialState after push', hooksLedger.initialState)
+        });
 
-        // store.subscribe(() => {
-        //   hooksLedger.dispCount = hooksLedger.dispCount;
-        //   // console.log('HOOKSLEDGER.DISPCOUNT', hooksLedger.dispCount)
-        // });
+        store.subscribe(() => {
+          hooksLedger.dispCount = hooksLedger.dispCount + 1;
+          // console.log('HOOKSLEDGER.DISPCOUNT', hooksLedger.dispCount)
+        });
 
         store.dispatch({
           type: reducerId,
@@ -67,11 +84,17 @@ const dispatch = useMemo<Dispatch<A>>(() => {
    return dispatch;
   }, []);
 
+
+
+  
   useEffect(() => {
     const teardown = store.registerHookedReducer(reducer, initialReducerState, reducerId);
     let lastReducerState = localState;
+    //console.log('local state ', localState)
     const unsubscribe = store.subscribe(() => {
+      //console.log('lastReducerstate ', lastReducerState)
       const storeState: any = store.getState();
+      //console.log('storeState', storeState)
       const reducerState = storeState[reducerId];
       if (lastReducerState !== reducerState) {
         setState(reducerState);
@@ -84,6 +107,7 @@ const dispatch = useMemo<Dispatch<A>>(() => {
     };
   }, []);
 
+    //console.log('local state', localState)
   // Returns a tuple
   return [localState, dispatch];
 

--- a/package/hooks_generator/hooks_src/hooks-types.ts
+++ b/package/hooks_generator/hooks_src/hooks-types.ts
@@ -5,4 +5,5 @@ export interface Ledger {
   initialState: any;
   currState: any;
   dispCount: number;
+  previousState: any;
 }

--- a/package/hooks_generator/hooks_src/output/hooks-output-utils.ts
+++ b/package/hooks_generator/hooks_src/output/hooks-output-utils.ts
@@ -23,29 +23,14 @@ export function testState(state: any, id: string | number) {
 //   }`
 // }
 
-//if state is an array, map over state using reducer to generate multiple tests when state changes
-//this bug still occuring in occuring in dispatch count
-export function testStateChange (state: any, id: string | number, dispCount: number) {
+export function testStateChange (state: any, id: string | number, previousState: Array<Object>) {
   
-  //use reduce to pass state element into tests 
-  if (Array.isArray(state)){
-  const initialAccVal = '';
-  
-  //item will be each value in state
-  const reducer = (acc, item, index = 0) => {
-    //use index to compare the previous state value with current item in state
-    index--;
-    //first expect test should be showing that the current state has changed from the previous state
-    return acc +  '\n' + `'should show that state in ${id} changes after every dispatch and the number of elements in state array should be equal to dispatch count', () => {
-      expect(${item}).not.toBe(${state[index]}));
-      expect(${state.length}).toBe(${dispCount});  
-    }`
-  }
+  // let resultStr = '';
+  // for (let i = 0; i < previousState.length; i++){
+  //   resultStr += `'should show that state changes after every dispatch', () => {
+  //     expect(${previousState[i][id]}).not.toBe(${previousState[i - 1][id]})}
+  //   }`
+  // }
 
-  const stateVals = state.reduce(reducer, initialAccVal);
-
-  return stateVals;
-  };
-
-
+  // return  resultStr;
 }

--- a/package/hooks_generator/hooks_src/output/hooks-output.ts
+++ b/package/hooks_generator/hooks_src/output/hooks-output.ts
@@ -7,7 +7,8 @@ import { importHooksId, testState, testStateChange } from './hooks-output-utils'
 export const hooksOutput = ({
   state,
   id,
-  dispCount
+  dispCount,
+  previousState
 }: Ledger): any =>
   `import { renderHook } from '@testing-library/react-hooks';
    import React, { useState } from 'react';
@@ -17,12 +18,8 @@ export const hooksOutput = ({
 } from '<ADD USESTATE HOOK FILEPATH >';
 
 describe('USESTATE', () => {
-
-  ${state}
-  ${id}
-  ${dispCount}
   
   it(${testState(state, id)});
 
-  it(${testStateChange(state, id, dispCount)})
+  it(${testStateChange(state, id, previousState)})
 });`;

--- a/package/hooks_generator/hooks_src/utils/hooks-ledger.ts
+++ b/package/hooks_generator/hooks_src/utils/hooks-ledger.ts
@@ -7,4 +7,5 @@ export const hooksLedger: Ledger = {
   initialState: '',
   currState: '',
   dispCount: 0,
+  previousState: [],
 };


### PR DESCRIPTION
## Types of changes
- [x ] New feature 
## Purpose
We created a new property in ledger 'previousState' to store all changes to state.
## Approach
This previous state array is necessary to add additional tests to our generated tests, which keep track of all changes of state.

